### PR TITLE
[FEATURE] reenables garbage collection with the boostqueue preventing…

### DIFF
--- a/Classes/Cache/StaticFileBackend.php
+++ b/Classes/Cache/StaticFileBackend.php
@@ -282,16 +282,15 @@ class StaticFileBackend extends StaticDatabaseBackend implements TransientBacken
 
     /**
      * Does garbage collection.
-     *
-     * Note: Do not check boostmode. If we check boost mode, we get the problem, that the core garbage collection drop
-     * the DB related part of StaticFileCache but not the files, because the "garbage collection" works directly on
-     * the caching backends and not on the caches itself. By ignoring the boost mode in this function we take care,
-     * that the StaticFileCache drop the file AND the db representation. Please take care, that you select both backends
-     * in the garbage collection task in the Scheduler.
      */
     public function collectGarbage(): void
     {
         $expiredIdentifiers = GeneralUtility::makeInstance(CacheRepository::class)->findExpiredIdentifiers();
+        if ($this->isBoostMode()) {
+            $this->getQueue()->addIdentifiers($expiredIdentifiers);
+            parent::collectGarbage();
+            return;
+        }
         parent::collectGarbage();
         foreach ($expiredIdentifiers as $identifier) {
             $this->removeStaticFiles($identifier);


### PR DESCRIPTION
Zuvor wurden die statischen Dateien (wenn expired) gelöscht was bei entsprechenden Dateimengen zu Systemperformanceproblemen führen konnte.

Sollte die cache_staticfilecache* Tabelle um 1Mio Einträge haben ist es sinnvoll den Frontend Cache einmal komplett zu leeren und die zwei Tabellen zu truncaten, da der JoinQuery praktisch nicht fertigzuwerden scheint.